### PR TITLE
Remove override for AuthDialog getInitialSize() to fix window size.

### DIFF
--- a/org.webcat.eclipse.projectlink/src/org/webcat/eclipse/projectlink/dialogs/AuthenticationDialog.java
+++ b/org.webcat.eclipse.projectlink/src/org/webcat/eclipse/projectlink/dialogs/AuthenticationDialog.java
@@ -148,17 +148,6 @@ public class AuthenticationDialog extends TitleAreaDialog
 
 
 	// ----------------------------------------------------------
-	/**
-	 * Return the initial size of the dialog.
-	 */
-	@Override
-	protected Point getInitialSize()
-	{
-		return new Point(482, 246);
-	}
-
-
-	// ----------------------------------------------------------
 	@Override
 	protected void okPressed()
 	{


### PR DESCRIPTION
The specified size for the AuthenticationDialog's getInitialSize() is too small on certain HiDPI displays. By removing the override, Eclipse decides an appropriate size based on the dialog content, ensuring that the user can see all components in the window. (This fixes a situation where, for myself and most of my students with newer laptops, none of the input fields for username/password were visible in the authentication dialog because the window was too small.)
